### PR TITLE
Adding bitnami postgresql helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -2558,29 +2558,15 @@ helm create backend
 sed -E \
 -e 's/^(description:).*/\1 Backend Flask app helmchart/' \
 -e 's/^(appVersion:).*/\1 v1.0.0 /' \
--e '$a  \\ndependencies: \n- name: postgresql \n  version: "3.18.3" \n  repository: "https://kubernetes-charts.storage.googleapis.com" \n' \
+-e '$a  \\ndependencies: \n- name: postgresql \n  version: "8.10.8" \n  repository: "https://charts.bitnami.com/bitnami" \n' \
 -i backend/Chart.yaml
 ```
 
 Download **postgresql** helm chart to a `backend/charts` folder and fix **apiVersion** errors in advance
 
 ```bash
-# Downloads helm chart: "postgresql-3.18.3.tgz" to charts/ folder
+# Downloads helm chart: to charts/ folder
 cd backend && helm dependency update && cd ..
-
-# Untar "backend/charts/postgresql-3.18.3.tgz" to folder: backend/charts/
-# and remove tarball "backend/charts/postgresql-3.18.3.tgz"
-tar xvzf \
-backend/charts/postgresql-3.18.3.tgz \
--C backend/charts && \
-rm backend/charts/postgresql-3.18.3.tgz
-
-# Fix API version for "StatefulSet" Kubernetes objects 
-sed -i 's/apiVersion: apps\/v1beta2/apiVersion: apps\/v1/g' \
-backend/charts/postgresql/templates/statefulset.yaml \
-backend/charts/postgresql/templates/statefulset-slaves.yaml
-
-helm package backend/charts/postgresql -d backend/charts && rm -rf backend/charts/postgresql
 ```
 
 **Setup** file: `backend/values.yaml` within **backend** helm chart
@@ -2614,9 +2600,10 @@ postgresql:
     tag: latest
     debug: true
 
-  postgresqlUsername: postgres
-
-  postgresqlPassword: password
+  global:
+    postgresql:
+      postgresqlUsername: postgres
+      postgresqlPassword: password
 
   persistence:
     enabled: false
@@ -3108,9 +3095,9 @@ releases:
 **Deploy** your **whole infrastracture** via `helmfile` binary
 
 ```bash
-helmfile --log-level=info  -f  hf-infrastracture.yaml template  --skip-deps
-helmfile --log-level=info  -f  hf-infrastracture.yaml sync  --skip-deps
-helmfile --log-level=info  -f  hf-infrastracture.yaml destroy
+helmfile -f  hf-infrastracture.yaml template
+helmfile -f  hf-infrastracture.yaml sync
+helmfile -f  hf-infrastracture.yaml destroy
 ```
 
 <!-- - [44. Terraform destroy fails](#44-terraform-destroy-fails)-->
@@ -3222,46 +3209,46 @@ export PSQL_DB_PORT="5432"
 
 
 ```bash
-helmfile --selector key=backend -f  hf-infrastracture-without-backend-frontend-nodeports.yaml template --skip-deps
+helmfile --selector key=backend -f  hf-infrastracture-without-backend-frontend-nodeports.yaml template 
 
-helmfile --selector app=backend -f hf-infrastracture-without-backend-frontend-nodeports.yaml template  --skip-deps
+helmfile --selector app=backend -f hf-infrastracture-without-backend-frontend-nodeports.yaml template  
 ```
 
 Template **frontend** helm chart deployment by using `--selecor flag`
 ```bash
-helmfile --selector key=frontend -f  hf-infrastracture-without-backend-frontend-nodeports.yaml template --skip-deps
+helmfile --selector key=frontend -f  hf-infrastracture-without-backend-frontend-nodeports.yaml template 
 
-helmfile --selector app=frontend -f  hf-infrastracture-without-backend-frontend-nodeports.yaml template --skip-deps
+helmfile --selector app=frontend -f  hf-infrastracture-without-backend-frontend-nodeports.yaml template 
 ```
 
 Template **nginx** helm chart deployment by using `--selecor flag`
 ```bash
-helmfile --selector key=nginx -f  hf-infrastracture-without-backend-frontend-nodeports.yaml template --skip-deps
+helmfile --selector key=nginx -f  hf-infrastracture-without-backend-frontend-nodeports.yaml template 
 
-helmfile --selector app=nginx -f  hf-infrastracture-without-backend-frontend-nodeports.yaml template --skip-deps
+helmfile --selector app=nginx -f  hf-infrastracture-without-backend-frontend-nodeports.yaml template 
 ```
 
 * **Install/Sync helm charts to AWS EKS Kubernetes cluster**
 
 *Install* **backend** helm chart deployment by using `--selecor flag`
 ```bash
-helmfile --selector key=backend -f  hf-infrastracture-without-backend-frontend-nodeports.yaml sync --skip-deps
+helmfile --selector key=backend -f  hf-infrastracture-without-backend-frontend-nodeports.yaml sync 
 
-helmfile --selector app=backend -f  hf-infrastracture-without-backend-frontend-nodeports.yaml sync  --skip-deps
+helmfile --selector app=backend -f  hf-infrastracture-without-backend-frontend-nodeports.yaml sync  
 ```
 
 *Install* **frontend** helm chart deployment by using `--selecor flag`
 ```bash
-helmfile --selector key=frontend -f  hf-infrastracture-without-backend-frontend-nodeports.yaml sync --skip-deps
+helmfile --selector key=frontend -f  hf-infrastracture-without-backend-frontend-nodeports.yaml sync 
 
-helmfile --selector app=frontend -f  hf-infrastracture-without-backend-frontend-nodeports.yaml sync --skip-deps
+helmfile --selector app=frontend -f  hf-infrastracture-without-backend-frontend-nodeports.yaml sync 
 ```
 
 *Install* **nginx** helm chart deployment by using `--selecor flag`
 ```bash
-helmfile --selector key=nginx -f  hf-infrastracture-without-backend-frontend-nodeports.yaml sync --skip-deps
+helmfile --selector key=nginx -f  hf-infrastracture-without-backend-frontend-nodeports.yaml sync 
 
-helmfile --selector app=nginx -f  hf-infrastracture-without-backend-frontend-nodeports.yaml sync  --skip-deps
+helmfile --selector app=nginx -f  hf-infrastracture-without-backend-frontend-nodeports.yaml sync  
 ```
 
 <!-- - [46. Connect to frontend and backend applications from inside of Nginx ingress controller pod](#46-connect-to-frontend-and-backend-applications-from-inside-of-nginx-ingress-controller-pod)-->
@@ -3301,14 +3288,14 @@ helmfile \
 --selector key=backend \
 --selector key=frontend \
 --selector key=nginx \
--f  hf-infrastracture-without-backend-frontend-nodeports.yaml template --skip-deps
+-f  hf-infrastracture-without-backend-frontend-nodeports.yaml template 
 
 # Deploy everything at once
 helmfile \
 --selector key=backend \
 --selector key=frontend \
 --selector key=nginx \
--f  hf-infrastracture-without-backend-frontend-nodeports.yaml sync --skip-deps
+-f  hf-infrastracture-without-backend-frontend-nodeports.yaml sync 
 
 # Check fot the result of helmfile deployment
 helm ls
@@ -3416,7 +3403,28 @@ curl -X POST   http://localhost:80/api/ipaddress
 curl -X DELETE "http://localhost:80/api/ipaddress?id=2"
 ```
 
+### 47. Deploy whole setup with Persistend storage for PostgreSQL database
 
+Adjust `/etc/hosts` file if you have not done it already
+
+```bash
+kubectl get nodes -o wide | awk -F" " '{print $7 "\tk8s-ingress-name"}' | grep -v "EXTER"
+```
+
+
+Deploy entire setup via `helmfile`
+```bash
+export MASTER_DB_PASS="password"
+export MASTER_DB_USER="postgres"
+
+## Credentials for user: micro, database: microservice
+export PSQL_ALLOWED_IPS="172.31.0.0/16"
+export PSQL_DB_USER="micro"
+export PSQL_DB_PASS="password"
+export PSQL_DB_NAME="microservice"
+export PSQL_DB_ADDRESS="backend-postgresql"
+export PSQL_DB_PORT="5432"
+```
 
 
 

--- a/eks-terraform/quick-access.md
+++ b/eks-terraform/quick-access.md
@@ -1,0 +1,91 @@
+**Reminder how to start AWS EKS cluster by terraform:**
+
+```bash
+git clone https://github.com/xjantoth/aws-eks-devopsinuse.git
+```
+
+to **comment** terraform files (getting back to initial clear state). This **helps** to get the terraform code to the state **right after fresh** `git clone https://github.com/xjantoth/aws-eks-devopsinuse.git` command.
+
+```bash
+sed -i 's/^/#/' iam.tf outputs.tf sg.tf subnets.tf
+sed -i '/^.*EKS_CLUSTER_START.*/,/^.*EKS_NODE_GROUP_END.*/s/^/#/' main.tf
+```
+
+* **uncomment** all files from `eks-terraform/` **folder** at once:
+
+```bash
+sed 's/^#//' -i iam.tf
+sed 's/^#//' -i sg.tf
+sed 's/^#//' -i subnets.tf
+sed 's/^#//' -i outputs.tf
+sed -e '/^.*EKS_CLUSTER_START.*/,/^.*EKS_CLUSTER_END.*/s/^#//' -i main.tf
+sed -e '/^.*EKS_NODE_GROUP_START.*/,/^.*EKS_NODE_GROUP_END.*/s/^#//' -i main.tf
+```
+`variables.tf` (this file is uncommented all the time)
+`outputs.tf` (does not really matter whether it's uncommented or not)
+
+**Delete** all **hidden** terraform `files/folders`:
+
+```
+echo "" > ~/.kube/config && cat ~/.kube/config
+cd eks-terraform
+rm terraform.tfstate.backup terraform.tfstate .terraform -rf
+ls  ~/.ssh/eks-aws.pub
+terraform init
+terraform validate
+terraform fmt -recursive
+```
+
+**Bring** up your AWS EKS Kubernetes cluster (this will take about ~15min)
+
+```bash
+terraform apply -var-file terraform.eks.tfvars
+```
+
+Update **KUBECONFIG** once AWS EKS cluster is up and running
+
+```bash
+aws eks \
+--region eu-central-1 \
+update-kubeconfig \
+--name diu-eks-cluster \
+--profile devopsinuse > &>/dev/null
+```
+
+
+**Add** output of this commnad to `/etc/hosts` file
+
+```bash
+kubectl get nodes -o wide | awk -F" " '{print $7 "\tk8s-ingress-name"}' | grep -v "EXTER"
+```
+
+**Work** with AWS EKS cluster ...
+
+```bash
+...
+kubectl get ... ...
+kubectl describe...
+kubectl run ...
+kubectl delete ...
+kubectl edit ...
+kubectl log ...
+kubectl explain ...
+kubectl expose ...
+kubectl apply ...
+kubectl create ...
+...
+```
+
+
+**Delete** up your AWS EKS Kubernetes cluster (this will take about ~15min)
+
+```bash
+# Please undeploy everyhting from your AWS EKS cluster
+helm delete <release-name>
+kubectl delete -f <file-name>.yaml
+
+# Once applications are undeployed, please run:
+terraform destroy -var-file terraform.eks.tfvars
+```
+
+

--- a/hf-infrastracture-with-psql-persistent-volume.yaml
+++ b/hf-infrastracture-with-psql-persistent-volume.yaml
@@ -1,0 +1,91 @@
+repositories:
+- name: stable
+  url:  https://kubernetes-charts.storage.googleapis.com
+- name: bitnami
+  url:  https://charts.bitnami.com/bitnami
+
+releases:
+  # (Helm v3) Upgrade your deployment with basic auth
+  - name: backend
+    labels:
+      key: backend
+      app: backend
+    
+    chart: backend/hc/backend
+    version: 0.1.0
+    set:
+    #- name: service.type
+    #  value: NodePort
+    #- name: service.nodePort
+    #  value: 30333
+    - name: replicaCount
+      value: 1
+    - name: ingress.enabled
+      value: true
+    - name: global.postgresql.postgresqlUsername
+      value: {{ requiredEnv "MASTER_DB_USER" }}
+    - name: global.postgresql.postgresqlPassword
+      value: {{ requiredEnv "MASTER_DB_PASS" }}
+    - name: image.env.secret.PSQL_DB_USER
+      value: {{ requiredEnv "PSQL_DB_USER" }}
+    - name: image.env.secret.PSQL_DB_PASS
+      value: {{ requiredEnv "PSQL_DB_PASS" }}
+    - name: image.env.secret.PSQL_DB_NAME
+      value: {{ requiredEnv "PSQL_DB_NAME" }}
+    - name: image.env.secret.PSQL_DB_ADDRESS
+      value: {{ requiredEnv "PSQL_DB_ADDRESS" }}
+    #- name: image.env.secret.PSQL_DB_PORT
+    #  value: \"{{ requiredEnv "PSQL_DB_PORT" }}\"
+
+    values:
+      - postgresql:
+          pgHbaConfiguration: |
+            local all all trust
+            host all all localhost trust
+            host {{ requiredEnv "PSQL_DB_NAME" }} {{ requiredEnv "PSQL_DB_USER" }} {{ requiredEnv "PSQL_ALLOWED_IPS" }} password
+          initdbScripts:
+            db-init.sql: |
+              CREATE DATABASE {{ requiredEnv "PSQL_DB_NAME" }};
+              CREATE USER {{ requiredEnv "PSQL_DB_USER" }} WITH ENCRYPTED PASSWORD '{{ requiredEnv "PSQL_DB_PASS" }}';
+              GRANT ALL PRIVILEGES ON DATABASE {{ requiredEnv "PSQL_DB_NAME" }} TO {{ requiredEnv "PSQL_DB_USER" }};
+              ALTER DATABASE {{ requiredEnv "PSQL_DB_NAME" }} OWNER TO {{ requiredEnv "PSQL_DB_USER" }};
+
+  # Frontend specification
+  - name: frontend
+    labels:
+      key: frontend
+      app: frontend
+
+    chart: frontend/hc/frontend
+    version: 0.1.0
+    set:
+    #- name: service.type
+    #  value: NodePort
+    #- name: service.nodePort
+    #  value: 30222
+    - name: replicaCount
+      value: 1
+    - name: ingress.enabled
+      value: true
+  
+  # Nginx Ingress Controller specification
+  - name: nginx
+    labels:
+      key: nginx
+      app: nginx
+
+    chart: stable/nginx-ingress
+    # version: 0.1.0
+    set:
+    - name: controller.service.type
+      value: NodePort
+    - name: controller.service.nodePorts.http
+      value: 30111
+
+# kubectl run postgresql-client \
+# --rm --tty -i --restart='Never' \ 
+# --namespace default \
+# --image docker.io/bitnami/postgresql:11.7.0-debian-10-r82 \
+# --env="PGPASSWORD=password" \
+# --command -- psql --host postgresql -U micro -d microservice -p 5432
+


### PR DESCRIPTION
Removing `stable/postgresql `helm chart as dependency for **backend** helm chart. Using **bitnami/postgresql** helm chart **instead**. 

Reason: helm charts usually use latest docker image versions (past state) and **deprecated**  `stable/postgresql `helm chart stopped working over the time because of incompatible variables from **values.yaml** file